### PR TITLE
backwards compatability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "@adobe/aep-rules-engine",
-  "version": "1.0.2",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/aep-rules-engine",
-      "version": "1.0.2",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.21.3",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@jsdevtools/npm-publish": "^2.0.0",
         "@lwc/eslint-plugin-lwc": "^1.6.2",
         "@rollup/plugin-babel": "^6.0.3",
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -2359,57 +2358,6 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
-    "node_modules/@jsdevtools/npm-publish": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/npm-publish/-/npm-publish-2.0.0.tgz",
-      "integrity": "sha512-hP65lToZ6A9tWK8OQynQHHjbPI1itifUOo9hWZ2CmICMdc+eZ40XmPw7nvmFvwRSfKkb7dvAtU5xrueEKHZ5jw==",
-      "dev": true,
-      "dependencies": {
-        "@types/semver": "^7.3.13",
-        "command-line-args": "^5.1.1",
-        "semver": "^7.5.0",
-        "tar": "^6.1.13"
-      },
-      "bin": {
-        "npm-publish": "bin/npm-publish.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@jsdevtools/npm-publish/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@jsdevtools/npm-publish/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@jsdevtools/npm-publish/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/@lwc/eslint-plugin-lwc": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-1.6.2.tgz",
@@ -3201,15 +3149,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
@@ -3644,15 +3583,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ci-info": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
@@ -3721,21 +3651,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/command-line-args": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
-      "dev": true,
-      "dependencies": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -4827,18 +4742,6 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
-    "node_modules/find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dev": true,
-      "dependencies": {
-        "array-back": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -4908,36 +4811,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -6496,12 +6369,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -6624,49 +6491,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/mri": {
@@ -7956,29 +7780,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tar": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
-      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
-      "dev": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^4.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/terser": {
       "version": "5.16.6",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.6.tgz",
@@ -8172,15 +7973,6 @@
       },
       "engines": {
         "node": ">=12.20"
-      }
-    },
-    "node_modules/typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/uglify-js": {
@@ -10146,44 +9938,6 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
-    "@jsdevtools/npm-publish": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/npm-publish/-/npm-publish-2.0.0.tgz",
-      "integrity": "sha512-hP65lToZ6A9tWK8OQynQHHjbPI1itifUOo9hWZ2CmICMdc+eZ40XmPw7nvmFvwRSfKkb7dvAtU5xrueEKHZ5jw==",
-      "dev": true,
-      "requires": {
-        "@types/semver": "^7.3.13",
-        "command-line-args": "^5.1.1",
-        "semver": "^7.5.0",
-        "tar": "^6.1.13"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
     "@lwc/eslint-plugin-lwc": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-1.6.2.tgz",
@@ -10743,12 +10497,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true
-    },
     "array-buffer-byte-length": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
@@ -11057,12 +10805,6 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
-    "chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true
-    },
     "ci-info": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
@@ -11112,18 +10854,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "command-line-args": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
-      "dev": true,
-      "requires": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      }
     },
     "commander": {
       "version": "2.20.3",
@@ -11933,15 +11663,6 @@
         "pkg-dir": "^4.1.0"
       }
     },
-    "find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dev": true,
-      "requires": {
-        "array-back": "^3.0.1"
-      }
-    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -11997,32 +11718,6 @@
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
-      }
-    },
-    "fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0"
-      },
-      "dependencies": {
-        "minipass": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
       }
     },
     "fs.realpath": {
@@ -13156,12 +12851,6 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -13257,39 +12946,6 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
       "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
-      "dev": true
-    },
-    "minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "minipass": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
     "mri": {
@@ -14212,28 +13868,6 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
-    "tar": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
-      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
-      "dev": true,
-      "requires": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^4.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
     "terser": {
       "version": "5.16.6",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.6.tgz",
@@ -14384,12 +14018,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
       "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
-      "dev": true
-    },
-    "typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aep-rules-engine",
-  "version": "3.0.0",
+  "version": "2.0.2",
   "description": "Adobe Experience Platform rules engine.",
   "repository": {
     "type": "git",

--- a/src/historical.spec.ts
+++ b/src/historical.spec.ts
@@ -55,6 +55,138 @@ describe("test helper functions", () => {
     const result = queryAndCountAnyEvent(events, context, from, to);
     expect(result).toBe(8);
   });
+  it("should work with property conditions not prefixed with 'iam'", () => {
+    const events = [
+      {
+        eventType: "display",
+        id: "abc",
+      },
+    ];
+    const context = {
+      events: {
+        display: {
+          abc: {
+            event: {
+              eventType: "display",
+              id: "abc",
+            },
+            timestamp: 1609086720000,
+            count: 2,
+          },
+        },
+      },
+    };
+    const from = 1609086720000;
+    const to = 1609086720000;
+    const result = queryAndCountAnyEvent(events, context, from, to);
+    expect(result).toBe(2);
+  });
+
+  it("should work with 'iam' prefixed property conditions", () => {
+    const events = [
+      {
+        "iam.eventType": "display",
+        "iam.id": "abc",
+      },
+    ];
+    const context = {
+      events: {
+        display: {
+          abc: {
+            event: {
+              "iam.eventType": "display",
+              "iam.id": "abc",
+            },
+            timestamp: 1609086720000,
+            count: 2,
+          },
+        },
+      },
+    };
+    const from = 1609086720000;
+    const to = 1609086720000;
+    const result = queryAndCountAnyEvent(events, context, from, to);
+    expect(result).toBe(2);
+  });
+
+  it("should  fail gracefully when event condition lacks properties", () => {
+    const events = [{}];
+    const context = {
+      events: {
+        display: {
+          abc: {
+            event: {
+              "iam.eventType": "display",
+              "iam.id": "abc",
+            },
+            timestamp: 1609086720000,
+            count: 2,
+          },
+        },
+      },
+    };
+    const from = 1609086720000;
+    const to = 1609086720000;
+    const result = queryAndCountAnyEvent(events, context, from, to);
+    expect(result).toBe(0);
+  });
+
+  it("should work with additional event properties - positive case", () => {
+    const events = [
+      {
+        "iam.eventType": "display",
+        "iam.id": "abc",
+        isSpecial: true,
+      },
+    ];
+    const context = {
+      events: {
+        display: {
+          abc: {
+            event: {
+              "iam.eventType": "display",
+              "iam.id": "abc",
+              isSpecial: true,
+            },
+            timestamp: 1609086720000,
+            count: 1,
+          },
+        },
+      },
+    };
+    const from = 1609086720000;
+    const to = 1609086720000;
+    const result = queryAndCountAnyEvent(events, context, from, to);
+    expect(result).toBe(1);
+  });
+
+  it("should work with additional event properties - negative case", () => {
+    const events = [
+      {
+        "iam.eventType": "display",
+        "iam.id": "abc",
+        isSpecial: true,
+      },
+    ];
+    const context = {
+      events: {
+        display: {
+          abc: {
+            event: {
+              "iam.eventType": "display",
+              "iam.id": "abc",
+            },
+            timestamp: 1609086720000,
+            count: 1,
+          },
+        },
+      },
+    };
+    const from = 1609086720000;
+    const to = 1609086720000;
+    const result = queryAndCountAnyEvent(events, context, from, to);
+    expect(result).toBe(0);
+  });
 
   it("should return total count of the number of events even if the `to` and `from` is undefined", () => {
     const events = [
@@ -95,7 +227,7 @@ describe("test helper functions", () => {
     expect(result).toBe(8);
   });
 
-  it("returns 1 (true )If all the events are ordered and within the time range", () => {
+  it("returns 1 (true) If all the events are ordered and within the time range", () => {
     jest.setTimeout(10000);
     const events = [
       { "iam.eventType": "display", "iam.id": "A" },
@@ -105,9 +237,21 @@ describe("test helper functions", () => {
     const context = {
       events: {
         display: {
-          A: { count: 1, timestamp: 1 },
-          B: { count: 1, timestamp: 2 },
-          C: { count: 1, timestamp: 3 },
+          A: {
+            count: 1,
+            timestamp: 1,
+            event: { "iam.eventType": "display", "iam.id": "A" },
+          },
+          B: {
+            count: 1,
+            timestamp: 2,
+            event: { "iam.eventType": "display", "iam.id": "B" },
+          },
+          C: {
+            count: 1,
+            timestamp: 3,
+            event: { "iam.eventType": "display", "iam.id": "C" },
+          },
         },
       },
     };

--- a/src/historical.ts
+++ b/src/historical.ts
@@ -15,7 +15,15 @@ import { HistoricalEvent } from "./types/schema";
 import { isUndefined } from "./utils/isUndefined";
 
 const IAM_ID = "iam.id";
+const ID = "id";
+
 const IAM_EVENT_TYPE = "iam.eventType";
+const EVENT_TYPE = "eventType";
+const TYPE = "type";
+
+const VALID_EVENT_TYPES = [IAM_EVENT_TYPE, EVENT_TYPE, TYPE];
+const VALID_EVENT_IDS = [IAM_ID, ID];
+
 export function checkForHistoricalMatcher(
   eventCount: number,
   matcherKey: SupportedMatcher,
@@ -39,6 +47,30 @@ export function checkForHistoricalMatcher(
   }
 }
 
+function oneOf(context: Context, properties: Array<string>) {
+  for (let i = 0; i < properties.length; i += 1) {
+    if (!isUndefined(context[properties[i]])) {
+      return context[properties[i]];
+    }
+  }
+  return undefined;
+}
+
+function eventSatisfiesCondition(
+  historicalEventCondition: HistoricalEvent,
+  eventContext: Context
+) {
+  const eventKeys = Object.keys(historicalEventCondition);
+  for (let i = 0; i < eventKeys.length; i += 1) {
+    const key = eventKeys[i];
+    const { event = {} } = eventContext;
+    if (event[eventKeys[i]] !== historicalEventCondition[key]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * This function is used to query and count any event
  * @param events
@@ -54,15 +86,32 @@ export function queryAndCountAnyEvent(
   to?: any
 ) {
   return events.reduce((countTotal, event) => {
-    const eventsOfType = context.events[event[IAM_EVENT_TYPE]];
+    const eventType = oneOf(event, VALID_EVENT_TYPES);
+
+    if (!eventType) {
+      return countTotal;
+    }
+
+    const eventsOfType = context.events[eventType];
     if (!eventsOfType) {
       return countTotal;
     }
 
-    const contextEvent = eventsOfType[event[IAM_ID]];
+    const eventId = oneOf(event, VALID_EVENT_IDS);
+
+    if (!eventId) {
+      return countTotal;
+    }
+
+    const contextEvent = eventsOfType[eventId];
     if (!contextEvent) {
       return countTotal;
     }
+
+    if (!eventSatisfiesCondition(event, contextEvent)) {
+      return countTotal;
+    }
+
     const { count: eventCount = 1 } = contextEvent;
     if (
       isUndefined(from) ||
@@ -96,12 +145,28 @@ export function queryAndCountOrderedEvent(
 ) {
   let previousEventTimestamp = from;
   const sameSequence = events.every((event) => {
-    const eventsOfType = context.events[event[IAM_EVENT_TYPE]];
+    const eventType = oneOf(event, VALID_EVENT_TYPES);
+    if (!eventType) {
+      return false;
+    }
+
+    const eventsOfType = context.events[eventType];
     if (!eventsOfType) {
       return false;
     }
 
-    const contextEvent = eventsOfType[event[IAM_ID]];
+    const eventId = oneOf(event, VALID_EVENT_IDS);
+
+    if (!eventId) {
+      return false;
+    }
+
+    const contextEvent = eventsOfType[eventId];
+
+    if (!eventSatisfiesCondition(event, contextEvent)) {
+      return false;
+    }
+
     if (
       contextEvent === null ||
       isUndefined(contextEvent) ||

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -48,8 +48,14 @@ export interface MatcherDefinition {
 }
 
 export interface HistoricalEvent {
-  "iam.eventType": string;
-  "iam.id": string;
+  "iam.eventType"?: string;
+  "iam.id"?: string;
+  id?: string;
+
+  eventType?: string;
+  type?: string;
+
+  [key: string]: any;
 }
 
 export interface HistoricalDefinition {


### PR DESCRIPTION
i wanted to find a way to keep backwards compatibility and avoid breaking changes.  In order to do that we need continue to support "type" and "id" as possible properties for an event.


I also noticed that we aren't checking any properties other than `iam.id` and `iam.eventType`.  But there will be conditions with additional properties such as

```
{
  "iam.eventType": "display",
  "iam.id": "abc",
  "company_membership": "costco"
}
```

I began experimenting in the code myself, and thought it would be easer to just Pr to your branch to you can see the gaps.

Please take a look @shandilya3 